### PR TITLE
add python interpreter

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,4 +1,3 @@
 [build-image]
-127.0.0.1
-
+127.0.0.1 ansible_python_interpreter="/usr/bin/env python"
 


### PR DESCRIPTION
add ansible_python_interpreter so OSX 10.11 doesnt complain about shade missing.
